### PR TITLE
use morph instead of class basename

### DIFF
--- a/src/Traits/AuthorizesRequests.php
+++ b/src/Traits/AuthorizesRequests.php
@@ -37,7 +37,7 @@ trait AuthorizesRequests
 
         $parameter = is_array($parameter) ? implode(',', $parameter) : $parameter;
 
-        $parameter = $parameter ?: Str::snake(class_basename($model));
+        $parameter = $parameter ?: app($model)->getMorphClass();
 
         foreach ($this->mapResourceAbilities() as $method => $ability) {
             $modelName = in_array($method, $this->resourceMethodsWithoutModels()) ? $model : $parameter;


### PR DESCRIPTION
Using class base name is not correct, for example if we have model called MemberTenantable, we will get member_tenantable from class_basename helper, but we must get member only as same as we save the ability entity type.