### PR TITLE
fix route with ModelNotFoundException

### DIFF
--- a/src/Exceptions/ExceptionHandler.php
+++ b/src/Exceptions/ExceptionHandler.php
@@ -150,8 +150,9 @@ class ExceptionHandler extends BaseExceptionHandler
         } elseif ($e instanceof ModelNotFoundException) {
             $model = Str::lower($e->getModel());
             $vendor = Str::before($model, '\\');
-            $resource = Str::afterLast($model, '\\');
-            $route = $request->accessarea().'.'.$vendor.'.'.Str::plural($resource).'.'.Str::plural($resource).'.index';
+            $module = Str::betweenFirst($model, '\\', '\\');
+            $resource = app($e->getModel())->getMorphClass();
+            $route = $request->accessarea().'.'.$vendor.'.'.Str::plural($module).'.'.Str::plural($resource).'.index';
             preg_match('/'.(Route::getPattern($resource) ?: '[a-zA-Z0-9-_]+').'/', $request->route($resource), $matches);
 
             return intend([


### PR DESCRIPTION
when we have Cortex\Auth\Models\MemberTenantable model, the generated route will be `adminarea.cortex.membertenantables.membertenantables.index` but the correct route should be `adminarea.cortex.auth.members.index` so we need to get the module name and the morph class for the resource.