### PR TITLE
check if the group exists before prepend the middleware

### DIFF
--- a/bootstrap/module.php
+++ b/bootstrap/module.php
@@ -46,7 +46,11 @@ return function () {
     Route::pattern('adminarea', route_pattern('adminarea'));
 
     // prepend middleware to the 'web' middleware group
-    Route::prependMiddlewareToGroup('web', SetSessionConfigRuntime::class);
+    if(Route::hasMiddlewareGroup('web')){
+        Route::prependMiddlewareToGroup('web', SetSessionConfigRuntime::class);
+    }else{
+        Route::middlewareGroup('web', [SetSessionConfigRuntime::class]);
+    }
 
     // Map relations
     Relation::morphMap([


### PR DESCRIPTION
depends on `prependMiddlewareToGroup` implementation we should check if the group exists or not, because if it doesn't exist, it will ignore adding the middleware to the group